### PR TITLE
JKNIG-3 Add CRUD operations to Book Entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [JKNIG-3] Add CRUD operations to Book Entity
+- Added endpoints in `BookController` to get by id, create, update, delete `BookEntity`
+- Implemented corresponding service methods in `BookService` for book CRUD operations

--- a/src/main/java/com/eugenscobich/ai/demo/project/controller/BookController.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/controller/BookController.java
@@ -1,12 +1,14 @@
 package com.eugenscobich.ai.demo.project.controller;
 
+import com.eugenscobich.ai.demo.project.entity.BookEntity;
 import com.eugenscobich.ai.demo.project.service.BookService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/books")
@@ -16,7 +18,35 @@ public class BookController {
     private final BookService bookService;
 
     @GetMapping
-    public List<com.eugenscobich.ai.demo.project.entity.BookEntity> getAllBooks() {
+    public List<BookEntity> getAllBooks() {
         return bookService.getBooks();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BookEntity> getBookById(@PathVariable Long id) {
+        Optional<BookEntity> book = bookService.getBookById(id);
+        return book.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<BookEntity> createBook(@RequestBody BookEntity bookEntity) {
+        BookEntity createdBook = bookService.createBook(bookEntity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdBook);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<BookEntity> updateBook(@PathVariable Long id, @RequestBody BookEntity bookEntity) {
+        Optional<BookEntity> updatedBook = bookService.updateBook(id, bookEntity);
+        return updatedBook.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBook(@PathVariable Long id) {
+        boolean deleted = bookService.deleteBook(id);
+        if (deleted) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
@@ -1,11 +1,12 @@
 package com.eugenscobich.ai.demo.project.service;
 
-import org.springframework.stereotype.Service;
 import com.eugenscobich.ai.demo.project.entity.BookEntity;
 import com.eugenscobich.ai.demo.project.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +15,27 @@ public class BookService {
 
     public List<BookEntity> getBooks() {
         return bookRepository.findAll();
+    }
+
+    public Optional<BookEntity> getBookById(Long id) {
+        return bookRepository.findById(id);
+    }
+
+    public BookEntity createBook(BookEntity bookEntity) {
+        return bookRepository.save(bookEntity);
+    }
+
+    public Optional<BookEntity> updateBook(Long id, BookEntity newBookData) {
+        return bookRepository.findById(id).map(book -> {
+            book.setName(newBookData.getName());
+            book.setIsbn(newBookData.getIsbn());
+            return bookRepository.save(book);
+        });
+    }
+
+    public boolean deleteBook(Long id) {
+        if (!bookRepository.existsById(id)) return false;
+        bookRepository.deleteById(id);
+        return true;
     }
 }


### PR DESCRIPTION
## JKNIG-3 Add CRUD operations to Book Entity
- Added CRUD (get by id, create, update, delete) endpoints to BookController.
- Implemented corresponding service methods in BookService.
- Updated CHANGELOG.md with summary of changes.

Endpoints:
- GET /books/{id}
- POST /books
- PUT /books/{id}
- DELETE /books/{id}

All logic follows modern Spring best practices and standard REST conventions.

ThreadId:[thread_hXrr8vDPpGswztDTYw25ajwc]