### PR TITLE
JKNIG-2 Add database integration with Postgres, BookEntity, repository and service update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.2] - 2025-05-16
+### Added
+- PostgreSQL 17 integration via application.properties and Maven dependency.
+- JPA entity BookEntity with id (sequence), name, isbn fields.
+- BookRepository interface using Spring Data JPA.
+- BookService now loads book data from repository.
+
 ## [0.0.1] - 2025-05-16
 ### Added
 - Used Lombok's @RequiredArgsConstructor in BookController, removed manual constructor injection.

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,15 @@
       <version>1.18.32</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.7.2</version>
+    </dependency>
   </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/eugenscobich/ai/demo/project/entity/BookEntity.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/entity/BookEntity.java
@@ -1,0 +1,27 @@
+package com.eugenscobich.ai.demo.project.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Entity
+@Table(name = "books")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BookEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String isbn;
+}

--- a/src/main/java/com/eugenscobich/ai/demo/project/repository/BookRepository.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/repository/BookRepository.java
@@ -1,0 +1,10 @@
+package com.eugenscobich.ai.demo.project.repository;
+
+import com.eugenscobich.ai.demo.project.entity.BookEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookRepository extends JpaRepository<BookEntity, Long> {
+    // Additional query methods if necessary
+}

--- a/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
@@ -3,16 +3,28 @@ package com.eugenscobich.ai.demo.project.service;
 import com.eugenscobich.ai.demo.project.model.Book;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
+import com.eugenscobich.ai.demo.project.entity.BookEntity;
+import com.eugenscobich.ai.demo.project.repository.BookRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class BookService {
+    private final BookRepository bookRepository;
+
+    @Autowired
+    public BookService(BookRepository bookRepository) {
+        this.bookRepository = bookRepository;
+    }
+
     public List<Book> getBooks() {
-        return Arrays.asList(
-                new Book("1", "Spring Boot in Action", "Craig Walls"),
-                new Book("2", "Effective Java", "Joshua Bloch"),
-                new Book("3", "Clean Code", "Robert C. Martin")
-        );
+        // Converts BookEntity to Book model if needed
+        return bookRepository.findAll().stream()
+            .map(entity -> new Book(
+                    entity.getId() != null ? entity.getId().toString() : null,
+                    entity.getName(),
+                    entity.getIsbn()))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
@@ -5,18 +5,15 @@ import org.springframework.stereotype.Service;
 
 import com.eugenscobich.ai.demo.project.entity.BookEntity;
 import com.eugenscobich.ai.demo.project.repository.BookRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class BookService {
     private final BookRepository bookRepository;
 
-    @Autowired
-    public BookService(BookRepository bookRepository) {
-        this.bookRepository = bookRepository;
-    }
 
     public List<Book> getBooks() {
         // Converts BookEntity to Book model if needed

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/books_store
-spring.datasource.username=postgres
-spring.datasource.password=postgres
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/books_store
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/books_store
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
- Integrated PostgreSQL 17 to the backend application using JPA with spring-boot-starter-data-jpa and official postgres driver.
- Added BookEntity JPA entity with id (auto-generated), name and isbn fields.
- Created BookRepository interface for entity persistence.
- Updated service layer (BookService) to serve books loaded from the new repository.
- Configuration (URL, user, pass, dialect, ddl-auto) provided for Postgres in application.properties.
- Updated CHANGELOG.md with new features and version.

The application now supports persistent book storage and retrieval from a PostgreSQL database. Dummy data usage in the service was removed in favor of repository-backed access.
ThreadId:[thread_DUjnhWrOZxfTRkCkPgbwb3qg]