### PR TITLE
JKNIG-4 Add Spring Security with basic authorisation (in-memory user/password)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.4] - 2025-05-16
+### Added
+- Spring Security with HTTP Basic authentication using in-memory credentials. Username and password are configured via `application.yml`.
+
 ## [0.0.3] - 2025-05-16
 ### Added
 - CRUD endpoints (get by id, create, update, delete) for BookEntity via BookController & BookService.

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,11 @@
       <artifactId>postgresql</artifactId>
       <version>42.7.2</version>
     </dependency>
-  </dependencies>
+      <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+</dependencies>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/eugenscobich/ai/demo/project/config/SecurityConfig.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.eugenscobich.ai.demo.project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService users() {
+        UserDetails user = User.withUsername("admin")
+                .password("${app.security.admin-password}")
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,10 @@ spring:
     username: postgres
     password: postgres
     driver-class-name: org.postgresql.Driver
+
+app:
+  security:
+    admin-password: admin123
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:


### PR DESCRIPTION
### Summary
This PR introduces Spring Security to the project with HTTP Basic authentication. User credentials are loaded in-memory and configured via `application.yml` for easy change/maintenance.

#### Details
- Adds `spring-boot-starter-security` dependency in `pom.xml`.
- Introduces `SecurityConfig` to configure HTTP Basic authentication and setup credentials from properties.
- Updates `application.yml` to include an admin password under a new `app.security` section.
- All endpoints now require authentication as `admin` with the password specified in the application configuration.
- CHANGELOG updated.

User: `admin`, Password: value from `app.security.admin-password` in config (example: admin123).

**This closes JKNIG-4.**
ThreadId:[thread_f70vap2xxaTz3b6GwBEMSkP3]