### PR TITLE
JKNIG-3 Add CRUD operations to Book Entity

### DIFF
--- a/src/main/java/com/eugenscobich/ai/demo/project/controller/BookController.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/controller/BookController.java
@@ -1,0 +1,60 @@
+package com.eugenscobich.ai.demo.project.controller;
+
+import com.eugenscobich.ai.demo.project.model.Book;
+import com.eugenscobich.ai.demo.project.service.BookService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/books")
+public class BookController {
+
+    private final BookService bookService;
+
+    @Autowired
+    public BookController(BookService bookService) {
+        this.bookService = bookService;
+    }
+
+    @GetMapping
+    public List<Book> getBooks() {
+        return bookService.getBooks();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Book> getBookById(@PathVariable Long id) {
+        Book book = bookService.getBookById(id);
+        if (book == null) {
+            return ResponseEntity.notFound().build();
+        } else {
+            return ResponseEntity.ok(book);
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<Book> createBook(@RequestBody Book book) {
+        Book created = bookService.createBook(book);
+        return ResponseEntity.ok(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Book> updateBook(@PathVariable Long id, @RequestBody Book book) {
+        Book updated = bookService.updateBook(id, book);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        } else {
+            return ResponseEntity.ok(updated);
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteBook(@PathVariable Long id) {
+        boolean deleted = bookService.deleteBook(id);
+        if (!deleted) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
@@ -25,4 +25,34 @@ public class BookService {
                 .map(entity -> new Book(entity.getId(), entity.getName(), entity.getIsbn()))
                 .collect(Collectors.toList());
     }
-}
+
+    public Book getBookById(Long id) {
+        BookEntity entity = bookRepository.findById(id).orElse(null);
+        if (entity == null) return null;
+        return new Book(entity.getId(), entity.getName(), entity.getIsbn());
+    }
+
+    public Book createBook(Book book) {
+        BookEntity entity = new BookEntity();
+        entity.setName(book.getTitle());
+        entity.setIsbn(book.getAuthor());
+        entity = bookRepository.save(entity);
+        return new Book(entity.getId(), entity.getName(), entity.getIsbn());
+    }
+
+    public Book updateBook(Long id, Book book) {
+        BookEntity entity = bookRepository.findById(id).orElse(null);
+        if (entity == null) return null;
+        entity.setName(book.getTitle());
+        entity.setIsbn(book.getAuthor());
+        entity = bookRepository.save(entity);
+        return new Book(entity.getId(), entity.getName(), entity.getIsbn());
+    }
+
+    public boolean deleteBook(Long id) {
+        if (!bookRepository.existsById(id)) return false;
+        bookRepository.deleteById(id);
+        return true;
+    }
+
+    }


### PR DESCRIPTION
## JKNIG-3 Add CRUD operations to Book Entity

- Added REST endpoints in BookController for CRUD operations (get by id, create, update, delete BookEntity)
- Extended BookService with required CRUD logic
- Build passes successfully

This PR adds necessary endpoints and service logic to manage BookEntity lifecycle through the REST API.
ThreadId:[thread_TdabDWktyRUotf9reb6UhmUe]