### PR TITLE
JKNIG-3 Add CRUD operations to Book Entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 ### Added
+- JKNIG-3: Added CRUD operations (get by id, create, update, delete) endpoints for BookEntity in BookController and BookService.
+
+### Added
 - JKNIG-2: Added PostgreSQL database integration, BookEntity, repository, and updated BookService to fetch books from DB.
 - Initial project skeleton using Spring Boot 3.4.4, Java 21 & Maven.
 - Book model, service with dummy data.

--- a/src/main/java/com/eugenscobich/ai/demo/project/controller/BookController.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/controller/BookController.java
@@ -7,6 +7,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
+
+import com.eugenscobich.ai.demo.project.model.BookEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/books")
@@ -20,5 +25,31 @@ public class BookController {
     @GetMapping
     public List<Book> getBooks() {
         return bookService.getAllBooks();
+    }
+
+    // --- CRUD for BookEntity ---
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BookEntity> getBookById(@PathVariable Long id) {
+        Optional<BookEntity> entity = bookService.getBookById(id);
+        return entity.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<BookEntity> createBook(@RequestBody BookEntity book) {
+        BookEntity saved = bookService.createBook(book);
+        return ResponseEntity.ok(saved);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<BookEntity> updateBook(@PathVariable Long id, @RequestBody BookEntity book) {
+        Optional<BookEntity> updated = bookService.updateBook(id, book);
+        return updated.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBook(@PathVariable Long id) {
+        boolean deleted = bookService.deleteBook(id);
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/service/BookService.java
@@ -4,7 +4,9 @@ import com.eugenscobich.ai.demo.project.model.Book;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
 
 import com.eugenscobich.ai.demo.project.repository.BookRepository;
 import com.eugenscobich.ai.demo.project.model.BookEntity;
@@ -23,5 +25,31 @@ public class BookService {
         return bookRepository.findAll().stream()
                 .map(entity -> new Book(entity.getName(), entity.getIsbn()))
                 .collect(Collectors.toList());
+    }
+
+    // --- CRUD for BookEntity ---
+
+    public Optional<BookEntity> getBookById(Long id) {
+        return bookRepository.findById(id);
+    }
+
+    public BookEntity createBook(BookEntity book) {
+        return bookRepository.save(book);
+    }
+
+    public Optional<BookEntity> updateBook(Long id, BookEntity newBook) {
+        return bookRepository.findById(id).map(existing -> {
+            existing.setName(newBook.getName());
+            existing.setIsbn(newBook.getIsbn());
+            return bookRepository.save(existing);
+        });
+    }
+
+    public boolean deleteBook(Long id) {
+        if (bookRepository.existsById(id)) {
+            bookRepository.deleteById(id);
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## JKNIG-3 Add CRUD operations to Book Entity

### Summary
- Added endpoints in BookController to support CRUD operations for BookEntity: get by id, create, update, delete.
- Extended BookService with the corresponding business logic for these operations.
- Updated CHANGELOG.md.
- Build verified successfully.

Details:
- GET /api/books/{id}: Get BookEntity by id.
- POST /api/books: Create new BookEntity.
- PUT /api/books/{id}: Update BookEntity.
- DELETE /api/books/{id}: Delete BookEntity.

No breaking changes. Ready for review.
ThreadId:[thread_bILuF3GTY9w659BT6isTxW3U]