### PR TITLE
JKNIG-4 Add Spring Security feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 ### Added
+- JKNIG-4: Added Spring Security with HTTP Basic authentication using in-memory credentials configured in application.yml. All endpoints now require authentication.
+### Added
 - JKNIG-3: Added CRUD operations (get by id, create, update, delete) endpoints for BookEntity in BookController and BookService.
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
       <version>42.7.1</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
   </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/eugenscobich/ai/demo/project/config/SecurityConfig.java
+++ b/src/main/java/com/eugenscobich/ai/demo/project/config/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.eugenscobich.ai.demo.project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated()
+            )
+            .httpBasic();
+        return http.build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,14 @@ spring:
     username: demo_user
     password: demo_pass
     driver-class-name: org.postgresql.Driver
+
+# Spring Security - in-memory authentication
+spring:
+  security:
+    user:
+      name: admin
+      password: admin123
+
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
### Summary
This PR implements JKNIG-4 by introducing Spring Security to the backend Book Store application.

### Details
- Added `spring-boot-starter-security` dependency to `pom.xml`.
- Created a `SecurityConfig` class that enables HTTP Basic authentication for all endpoints, disables CSRF.
- Configured an in-memory user (`admin`/`admin123`) in `application.yml`.
- Updated `CHANGELOG.md` with a summary of this security feature.

All API endpoints now require authentication via HTTP Basic using the provided in-memory credentials.
ThreadId:[thread_NGwYKz8U3bUEigvExAVFEUJJ]