### PR TITLE
JKNIG-5 Add support for Flyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 ### Added
+- JKNIG-5: Added Flyway database migration, initial migration for books table, configured Spring Boot to use migrations and validate with Hibernate.
+
+### Added
 - JKNIG-4: Added Spring Security with HTTP Basic authentication using in-memory credentials configured in application.yml. All endpoints now require authentication.
 ### Added
 - JKNIG-3: Added CRUD operations (get by id, create, update, delete) endpoints for BookEntity in BookController and BookService.

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
   </dependencies>
     <build>
         <plugins>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,12 @@ spring:
     password: demo_pass
     driver-class-name: org.postgresql.Driver
 
+  flyway:
+    enabled: true
+    validate-on-migrate: true
+    locations: classpath:db/migration
+
 # Spring Security - in-memory authentication
-spring:
   security:
     user:
       name: admin
@@ -14,7 +18,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/db/migration/V1__init_books.sql
+++ b/src/main/resources/db/migration/V1__init_books.sql
@@ -1,0 +1,6 @@
+-- Migration V1: Initial creation of books table for BookEntity
+CREATE TABLE IF NOT EXISTS books (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    isbn VARCHAR(255) NOT NULL UNIQUE
+);


### PR DESCRIPTION
## What was done
- Integrated Flyway as a database migration tool (added dependency and configuration in pom.xml and application.yml)
- Created the initial Flyway migration script to cover the BookEntity (`books` table schema)
- Changed Spring JPA config to validate schema via Hibernate and always use Flyway for DB structure

## Technical details
- Flyway migration scripts now live in `src/main/resources/db/migration`.
- DDL-auto is now set to `validate` so Hibernate checks DB structure, but structure is controlled by migration scripts.

## Testing
- Build and migration validated successfully via `mvn clean install`.

## Related to: JKNIG-5
ThreadId:[thread_FHUUXSnqy1iEGQPDtZ2KPy0q]